### PR TITLE
Hash and check passwords

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -3,6 +3,7 @@ import os
 from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
+from flask_bcrypt import Bcrypt
 
 app_name = 'tableflip'
 app = Flask(app_name)
@@ -15,5 +16,7 @@ app.secret_key = os.environ.get('SECRET_KEY')
 
 CORS(app, supports_credentials=True)
 db = SQLAlchemy(app)
+
+bcrypt = Bcrypt(app)
 
 from api import models, views

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 alembic==0.9.5
+bcrypt==3.1.4
 certifi==2017.7.27.1
+cffi==1.11.2
 chardet==3.0.4
 click==6.7
 decorator==4.1.2
 Flask==0.12.2
+Flask-Bcrypt==0.7.1
 Flask-Cors==3.0.3
 Flask-HTTPAuth==3.2.3
 Flask-Migrate==2.1.1
@@ -16,6 +19,7 @@ MarkupSafe==1.0
 passlib==1.7.1
 pbr==3.1.1
 psycopg2==2.7.3.1
+pycparser==2.18
 python-dateutil==2.6.1
 python-editor==1.0.3
 requests==2.18.4


### PR DESCRIPTION
Password hashes are encoded to base64 to store in the database because the model type was String and I didn't want to do migrations and stuff. It's okay though because it's exactly as secure as storing the same information in bits.