### PR TITLE
Remove GameType model, use string instead.

### DIFF
--- a/api/engine.py
+++ b/api/engine.py
@@ -4,6 +4,13 @@ import requests
 ENGINE_PORT = os.environ.get('ENGINE_PORT', 3000)
 ENGINE_URL = 'http://localhost:{}'.format(ENGINE_PORT)
 
+def game_types():
+  r = requests.get('{}/types'.format(ENGINE_URL))
+  if r.status_code == requests.codes.ok:
+    return r.json()
+  else:
+    raise Exception(r.json()['error'])
+
 def engine_query(game, endpoint, params):
   r = requests.post('{}/{}/{}'.format(ENGINE_URL, game, endpoint),
                     json=params)

--- a/api/models.py
+++ b/api/models.py
@@ -35,8 +35,7 @@ class Lobby(db.Model):
   __tablename__ = 'lobby'
   id = db.Column(db.Integer, primary_key=True)
   users = db.relationship('UserLobby', back_populates='lobby')
-  gametype_id = db.Column(db.Integer, db.ForeignKey('gametype.id'))
-  gametype = db.relationship('GameType')
+  gametype = db.Column(db.String(16))
   game_id = db.Column(db.Integer, db.ForeignKey('game.id'), nullable=True)
   game = db.relationship('Game')
 
@@ -50,15 +49,14 @@ class Game(db.Model):
   state = db.Column(db.JSON())
   users = db.relationship('UserGame', back_populates='game')
   finished = db.Column(db.Boolean, default=False)
-  gametype_id = db.Column(db.Integer, db.ForeignKey('gametype.id'))
-  gametype = db.relationship('GameType')
+  gametype = db.Column(db.String(16))
 
   @classmethod
   def create_from_lobby(self, lobby):
     userlobbies = lobby.users
 
     # Get inital state from game engine.
-    response = engine.initial_state(lobby.gametype.code, len(userlobbies))
+    response = engine.initial_state(lobby.gametype, len(userlobbies))
 
     game = Game(state=response['game_state'], finished=response['finished'], gametype=lobby.gametype)
     db.session.add(game)
@@ -78,19 +76,8 @@ class Game(db.Model):
     return game
 
   def __repr__(self):
-    return '<Game id=%r gametype_id=%r finished=%r>' % (
-        self.id, self.gametype_id, self.finished)
-
-class GameType(db.Model):
-  __tablename__ = 'gametype'
-  id = db.Column(db.Integer, primary_key=True)
-  code = db.Column(db.String(255), unique=True) # API identifier
-  name = db.Column(db.String(255)) # Human-readable name
-  min_players = db.Column(db.Integer)
-  max_players = db.Column(db.Integer)
-
-  def __repr__(self):
-    return '<GameType id=%r code=%r name=%r)>' % (self.id, self.code, self.name)
+    return '<Game id=%r gametype=%r finished=%r>' % (
+        self.id, self.gametype, self.finished)
 
 def init_db():
   db.drop_all()
@@ -100,16 +87,12 @@ def ensure_db_exists():
   db.create_all()
 
 def sample_data():
-  gametype = GameType(code='connect4', name='Connect 4',
-      min_players=2, max_players=2)
-  db.session.add(gametype)
-
   user = User(username='foo', password='bar')
   db.session.add(user)
   user2 = User(username='baz', password='bar')
   db.session.add(user2)
 
-  game = Game(gametype=gametype, state={
+  game = Game(gametype='connect4', state={
     'board': [[-1 for i in range(7)] for j in range(6)],
     'current_player': 0,
     'winner': -1})
@@ -125,7 +108,7 @@ def sample_data():
   # user.games.append(usergame)
   db.session.add(usergame)
 
-  lobby = Lobby(gametype=gametype)
+  lobby = Lobby(gametype='connect4')
   db.session.add(lobby)
 
   userlobby = UserLobby(user=user, lobby=lobby)

--- a/api/views.py
+++ b/api/views.py
@@ -21,9 +21,7 @@ def user_view(user, player_id=None):
 def lobby_view(lobby):
   obj = {
     "id": lobby.id,
-    "type": lobby.gametype.code,
-    "min_players": lobby.gametype.min_players,
-    "max_players": lobby.gametype.max_players,
+    "type": lobby.gametype,
     "players": [user_view(lobbygame.user) for lobbygame in lobby.users]
   }
   if lobby.game_id is not None:
@@ -33,7 +31,7 @@ def lobby_view(lobby):
 def game_view(game, include_view=False, player_id=-1):
   obj = {
     "id": game.id,
-    "type": game.gametype.code,
+    "type": game.gametype,
     "finished": game.finished,
     "players": [user_view(usergame.user, usergame.player_id)
                 for usergame in game.users],
@@ -41,7 +39,7 @@ def game_view(game, include_view=False, player_id=-1):
                 for usergame in game.users if usergame.winner]
   }
   if include_view:
-    obj["view"] = engine.player_view(game.gametype.code, game.state, player_id)
+    obj["view"] = engine.player_view(game.gametype, game.state, player_id)
   return obj
 
 def game_type_view(game_type):
@@ -141,7 +139,9 @@ def endpoint_lobbies():
       abort(403)
 
     data = request.get_json()
-    gametype = models.GameType.query.filter_by(code=data['type']).one()
+    gametype = data['type']
+    if gametype not in engine.game_types():
+      abort(403)
 
     new_lobby = models.Lobby(gametype=gametype)
     db.session.add(new_lobby)
@@ -162,7 +162,8 @@ def join_lobby(lobby_id):
                                                  lobby_id=lobby.id).first()
     if userlobby is None:
       # Lobby must have space
-      if len(lobby.users) + 1 > lobby.gametype.max_players:
+      max_players = engine.game_types()[lobby.gametype]['max_players'];
+      if len(lobby.users) + 1 > max_players:
         raise Exception('lobby is full')
       userlobby = models.UserLobby(user=g.user, lobby=lobby)
       db.session.add(userlobby)
@@ -255,7 +256,7 @@ def perform_action(game_id):
     player_id = usergame.player_id if usergame else -1
 
     data = request.get_json()
-    result = engine.perform_action(game.gametype.code, game.state, player_id, data['action'])
+    result = engine.perform_action(game.gametype, game.state, player_id, data['action'])
 
     game.state = result['game_state']
     game.finished = result['finished']

--- a/engine/index.js
+++ b/engine/index.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var app = express();
+var game_types = require('../games/nodeindex.js');
 
 var gameRouter = express.Router();
 
@@ -124,6 +125,9 @@ gameRouter.route('/:game/info').post(function(req, res) {
   }
 });
 
+app.get('/types', function(req, res) {
+  res.send(game_types);
+});
 app.use(bodyParser.json());
 app.use('/', gameRouter);
 

--- a/games/connect4/View.vue
+++ b/games/connect4/View.vue
@@ -32,7 +32,7 @@
         }'
       )
     .winner(v-if='state.winner != -1')
-      | Winner is {{ username(state.current_player) }}
+      | Winner is {{ username(state.winner) }}
       br
       .cell(
         :class='{ \

--- a/games/index.js
+++ b/games/index.js
@@ -1,23 +1,25 @@
+import games from './nodeindex';
+
 export default {
   connect4: {
-    name: 'Connect 4',
+    name: games.connect4.name,
+    min_players: games.connect4.min_players,
+    max_players: games.connect4.max_players,
     view: () => import('./connect4/View'),
     rules: () => import('./connect4/rules'),
-    min_players: 2,
-    max_players: 2,
   },
   quarto: {
-    name: 'Quarto',
+    name: games.quarto.name,
+    min_players: games.quarto.min_players,
+    max_players: games.quarto.max_players,
     view: () => import('./quarto/View'),
     rules: () => import('./quarto/rules'),
-    min_players: 2,
-    max_players: 2,
   },
   hanabi: {
-    name: 'Hanabi',
+    name: games.hanabi.name,
+    min_players: games.hanabi.min_players,
+    max_players: games.hanabi.max_players,
     view: () => import('./hanabi/View'),
     rules: () => import('./hanabi/rules'),
-    min_players: 2,
-    max_players: 5,
   },
 };

--- a/games/nodeindex.js
+++ b/games/nodeindex.js
@@ -1,0 +1,17 @@
+module.exports = {
+  connect4: {
+    name: 'Connect 4',
+    min_players: 2,
+    max_players: 2,
+  },
+  quarto: {
+    name: 'Quarto',
+    min_players: 2,
+    max_players: 2,
+  },
+  hanabi: {
+    name: 'Hanabi',
+    min_players: 2,
+    max_players: 5,
+  },
+};

--- a/web/src/components/pages/LobbiesPage.vue
+++ b/web/src/components/pages/LobbiesPage.vue
@@ -17,10 +17,10 @@
             .bignum {{ lobby.players.length }}
           .lobby-section
             h2 Required players
-            .bignum(v-if='lobby.min_players === lobby.max_players')
-              | {{ lobby.min_players }}
+            .bignum(v-if='games[lobby.type].min_players === games[lobby.type].max_players')
+              | {{ games[lobby.type].min_players }}
             .bignum(v-else)
-              | {{ lobby.min_players }} – {{ lobby.max_players }}
+              | {{ games[lobby.type].min_players }} – {{ games[lobby.type].max_players }}
         .lobby-controls
           button.even(@click='viewDetails(lobby.id)') View
 </template>

--- a/web/src/components/pages/LobbyDetailPage.vue
+++ b/web/src/components/pages/LobbyDetailPage.vue
@@ -16,10 +16,10 @@
             .bignum {{ lobby.players.length }}
           .lobby-section
             h2 Required players
-            .bignum(v-if='lobby.min_players === lobby.max_players')
-              | {{ lobby.min_players }}
+            .bignum(v-if='games[lobby.type].min_players === games[lobby.type].max_players')
+              | {{ games[lobby.type].min_players }}
             .bignum(v-else)
-              | {{ lobby.min_players }} – {{ lobby.max_players }}
+              | {{ games[lobby.type].min_players }} – {{ games[lobby.type].max_players }}
         .lobby-row
           .lobby-section
             h2 Current players
@@ -34,7 +34,7 @@
           template(v-if='!lobby.game_id')
             button(v-if='in_lobby' @click='leave' key='leave') Leave
             button(v-else @click='join' key='join') Join
-            button(@click='start' v-if='lobby.players.length >= lobby.min_players') Start
+            button(@click='start' v-if='lobby.players.length >= games[lobby.type].min_players') Start
           button(v-else @click='view_game') View Game
 </template>
 <script>


### PR DESCRIPTION
Serve available game types from engine. Jim was right, this is better.

Node can't import modules that use the `import` keyword, so there's a bit of a hack to get that to work. An alternatives would be automatically generating `nodeindex.js` from `index.js` by running it through `sed` before starting the game engine, but that might be more hacky.